### PR TITLE
Scripting

### DIFF
--- a/constellation-load-generator/v1/src/services/setInterceptors.js
+++ b/constellation-load-generator/v1/src/services/setInterceptors.js
@@ -27,9 +27,10 @@ const processResponse = (response) => {
  *
  * @param {AxiosInstance} axios
  * @param {array} calls
+ * @returns function to remove interceptors from axios instance
  */
 const setInterceptors = (axios, calls) => {
-  axios.interceptors.request.use(config => {
+  const requestInterceptor = axios.interceptors.request.use(config => {
     const { headers, method, url, data } = config;
     config.metadata = {
       callID: callCounter,
@@ -44,13 +45,20 @@ const setInterceptors = (axios, calls) => {
     return Promise.reject(error);
   });
 
-  axios.interceptors.response.use(response => {
+  const responseInterceptor = axios.interceptors.response.use(response => {
     calls.push(processResponse(response));
     return response;
   }, error => {
     calls.push(processResponse(error.response));
     return error;
   });
+
+  const clearInterceptors = () => {
+    axios.interceptors.request.eject(requestInterceptor);
+    axios.interceptors.response.eject(responseInterceptor);
+  };
+
+  return clearInterceptors;
 };
 
 export default setInterceptors;

--- a/constellation-load-generator/v1/src/services/setInterceptors.js
+++ b/constellation-load-generator/v1/src/services/setInterceptors.js
@@ -3,19 +3,39 @@
 let callCounter = 0;
 
 /**
+ * Gets data from axios metadata and response to construct the call log
+ *
+ * @param {AxiosResponse} response
+ * @returns call log object
+ */
+const processResponse = (response) => {
+  const metadata = response.config.metadata;
+  const startTime = metadata.startTime;
+  const endTime = Date.now();
+
+  const latency = endTime - startTime;
+  const { callID, request } = metadata;
+
+  const { status, statusText, headers, data } = response;
+  response = {status, statusText, headers, data};
+
+  return { callID, request, response, latency }
+}
+
+/**
  * Assigns the axios interceptor functions to given axios instance
  *
  * @param {AxiosInstance} axios
- * @param {array} results
+ * @param {array} calls
  */
-const setInterceptors = (axios, results) => {
+const setInterceptors = (axios, calls) => {
   axios.interceptors.request.use(config => {
     const { headers, method, url, data } = config;
     config.metadata = {
       callID: callCounter,
       request: {headers, method, url, data},
       startTime: Date.now(),
-      resultIndex: results.length - 1
+      resultIndex: calls.length - 1
     };
     callCounter++;
 
@@ -25,22 +45,11 @@ const setInterceptors = (axios, results) => {
   });
 
   axios.interceptors.response.use(response => {
-    const metadata = response.config.metadata;
-    const startTime = metadata.startTime;
-    const endTime = Date.now();
-
-    metadata.endTime = endTime;
-    metadata.latency = endTime - startTime;
-
-    const { callID, request, latency } = metadata;
-    const { status, statusText, headers, data } = response;
-    response = {status, statusText, headers, data};
-
-    results.push({ callID, request, response, latency });
-
+    calls.push(processResponse(response));
     return response;
   }, error => {
-    return Promise.reject(error);
+    calls.push(processResponse(error.response));
+    return error;
   });
 };
 

--- a/constellation-load-generator/v1/test_script/test_script.js
+++ b/constellation-load-generator/v1/test_script/test_script.js
@@ -3,8 +3,8 @@
 import { sleep } from "../src/utils/sleep.js";
 
 export const options = {
-  vus: 200,
-  duration: 60000,
+  vus: 1,
+  duration: 15000,
   async script(axiosInstance) {
     await axiosInstance.post(
       "http://localhost:5000/target",

--- a/constellation-load-generator/v1/test_script/test_script.js
+++ b/constellation-load-generator/v1/test_script/test_script.js
@@ -3,13 +3,17 @@
 import { sleep } from "../src/utils/sleep.js";
 
 export const options = {
-  vus: 1,
-  duration: 500,
-  async test(axiosInstance) {
+  vus: 200,
+  duration: 60000,
+  async script(axiosInstance) {
     await axiosInstance.post(
       "http://localhost:5000/target",
       { timeStamp: Date.now() }
     );
-    await sleep(1000);
+    await sleep(500);
+    await axiosInstance.get("http://localhost:5000/target")
+    await sleep(500)
+    await axiosInstance.get("http://localhost:5000")
+    await sleep(1500)
   }
 }


### PR DESCRIPTION
#19 

Major changes: 
The axios instance creation was moved to the for loop, so there is one axios instance per VU
The interceptors are created and removed per test so that they can access the most recent test object
The interceptors were refactored to create a clearInterceptors function and allow for failed responses
A couple miscellaneous name changes and refactors